### PR TITLE
Provide better trace info

### DIFF
--- a/src/Domain/Query/FetchMessage.php
+++ b/src/Domain/Query/FetchMessage.php
@@ -53,7 +53,7 @@ final class FetchMessage implements FetchMessageInterface
             ->withMessageDetails($this->serializer->serialize($message->getMessage(), 'json'))
             ->withMessageBusName($message->last(BusNameStamp::class)?->getBusName())
             ->withMessageOriginalTransport($message->last(SentToFailureTransportStamp::class)?->getOriginalReceiverName())
-            ->withErrorTrace($lastErrorStamp?->getFlattenException()?->getTraceAsString())
+            ->withErrorTrace($lastErrorStamp?->getFlattenException()?->getAsString())
             ->withFailedDates(...array_map(
                 fn (RedeliveryStamp $stamp): \DateTimeInterface => $stamp->getRedeliveredAt(),
                 $message->all(RedeliveryStamp::class)

--- a/tests/Unit/Presentation/Controller/Admin/RequeueControllerTest.php
+++ b/tests/Unit/Presentation/Controller/Admin/RequeueControllerTest.php
@@ -55,7 +55,7 @@ class RequeueControllerTest extends TestCase
             'identifiers' => [1, 2],
         ]));
 
-        $this->handler->__invoke(1)->willThrow(new \RuntimeException('Something failed'));
+        $this->handler->__invoke(1)->willThrow(new RuntimeException('Something failed'));
 
         $response = ($this->controller)($request);
 

--- a/tests/Unit/Presentation/Controller/Admin/RetryControllerTest.php
+++ b/tests/Unit/Presentation/Controller/Admin/RetryControllerTest.php
@@ -55,7 +55,7 @@ class RetryControllerTest extends TestCase
             'identifiers' => [1, 2],
         ]));
 
-        $this->handler->__invoke(1)->willThrow(new \RuntimeException('Something failed'));
+        $this->handler->__invoke(1)->willThrow(new RuntimeException('Something failed'));
 
         $response = ($this->controller)($request);
 


### PR DESCRIPTION
This PR provides better trace information.
Instead of returning solely the trace of the main exception, it returns all previous exceptions with trace (similar to the exceptions you get in the console)


Example : 

![Screenshot 2024-01-09 at 12 29 44](https://github.com/tailrdigital/sulu-messenger-failed-queue-bundle/assets/1618158/7ffaaf90-9354-434c-a7f1-8c77dc0d9c09)
