### PR TITLE
Add dynamic route generation for the js api implementation

### DIFF
--- a/assets/admin/api/fetchMessage.js
+++ b/assets/admin/api/fetchMessage.js
@@ -1,6 +1,7 @@
 import {Requester} from "sulu-admin-bundle/services";
 import {runActionOnServer} from "../utilities/run-action-on-server";
 import {tryParseFailedMessage} from "../types/failed-message";
+import symfonyRouting from "fos-jsrouting/router";
 
 /**
  * @param {number} messageId
@@ -10,7 +11,7 @@ export async function fetchMessage(
     messageId,
 ) {
     const response = await runActionOnServer(
-        Requester.get(`/admin/api/messenger-failed-queue/${messageId}`)
+        Requester.get(symfonyRouting.generate('tailr.messenger_failed_queue_fetch', {id: messageId}))
     );
 
     return tryParseFailedMessage(response);

--- a/assets/admin/api/retryMessage.js
+++ b/assets/admin/api/retryMessage.js
@@ -1,5 +1,6 @@
 import {Requester} from "sulu-admin-bundle/services";
 import {runActionOnServer} from "../utilities/run-action-on-server";
+import symfonyRouting from "fos-jsrouting/router";
 
 /**
  * @param {number[]} messageIdentifiers
@@ -11,7 +12,7 @@ export async function retryMessage(
     withRequeue,
 ) {
     await runActionOnServer(
-        Requester.put(`/admin/api/messenger-failed-queue/${withRequeue ? 'requeue' : 'retry'}`, {
+        Requester.put(symfonyRouting.generate(`tailr.messenger_failed_queue_${withRequeue ? 'requeue' : 'retry'}`), {
             identifiers: messageIdentifiers
         })
     );

--- a/src/Presentation/Controller/Admin/DeleteController.php
+++ b/src/Presentation/Controller/Admin/DeleteController.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Tailr\SuluMessengerFailedQueueBundle\Domain\Command\DeleteHandlerInterface;
 
-#[Route(path: '/messenger-failed-queue/{id}', name: 'app.messenger_failed_queue_delete', methods: ['DELETE'])]
+#[Route(path: '/messenger-failed-queue/{id}', name: 'tailr.messenger_failed_queue_delete', methods: ['DELETE'])]
 final class DeleteController extends AbstractSecuredMessengerFailedQueueController implements SecuredControllerInterface
 {
     public function __construct(

--- a/src/Presentation/Controller/Admin/RequeueController.php
+++ b/src/Presentation/Controller/Admin/RequeueController.php
@@ -16,7 +16,7 @@ use function Psl\Type\int;
 use function Psl\Type\shape;
 use function Psl\Type\vec;
 
-#[Route(path: '/messenger-failed-queue/requeue', name: 'app.messenger_failed_queue_requeue', methods: ['PUT'])]
+#[Route(path: '/messenger-failed-queue/requeue', name: 'tailr.messenger_failed_queue_requeue', methods: ['PUT'])]
 final class RequeueController extends AbstractSecuredMessengerFailedQueueController implements SecuredControllerInterface
 {
     public function __construct(

--- a/src/Presentation/Controller/Admin/RequeueController.php
+++ b/src/Presentation/Controller/Admin/RequeueController.php
@@ -16,7 +16,7 @@ use function Psl\Type\int;
 use function Psl\Type\shape;
 use function Psl\Type\vec;
 
-#[Route(path: '/messenger-failed-queue/requeue', name: 'tailr.messenger_failed_queue_requeue', methods: ['PUT'])]
+#[Route(path: '/messenger-failed-queue/requeue', name: 'tailr.messenger_failed_queue_requeue', options: ['expose' => true], methods: ['PUT'])]
 final class RequeueController extends AbstractSecuredMessengerFailedQueueController implements SecuredControllerInterface
 {
     public function __construct(

--- a/src/Presentation/Controller/Admin/RetryController.php
+++ b/src/Presentation/Controller/Admin/RetryController.php
@@ -16,7 +16,7 @@ use function Psl\Type\int;
 use function Psl\Type\shape;
 use function Psl\Type\vec;
 
-#[Route(path: '/messenger-failed-queue/retry', name: 'tailr.messenger_failed_queue_retry', methods: ['PUT'])]
+#[Route(path: '/messenger-failed-queue/retry', name: 'tailr.messenger_failed_queue_retry', options: ['expose' => true], methods: ['PUT'])]
 final class RetryController extends AbstractSecuredMessengerFailedQueueController implements SecuredControllerInterface
 {
     public function __construct(


### PR DESCRIPTION
In our customer project we need to prefix all sulu api calls with `sulu`.

This is easily done in the yaml configuration e.g.:

```yaml
    tailr_failed_queue:
        resource: '@SuluMessengerFailedQueueBundle/Presentation/Controller/Admin'
        type: attribute
        prefix: /sulu/admin/api
```

Unfortunately the javascript implementation was hardcoded to the specific route. 

This MR uses the `symfonyRouting` service from the `fos-jsrouting/router` to resolve the given symfony route.